### PR TITLE
Added validators to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pipreqs==0.4.6
 requests==2.10.0
 nose==1.3.7
+validators==0.12.2

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
   keywords=['contrast', 'security'],
   classifiers=[],
   install_requires=[
-    'requests'
+    'requests',
+    'validators'
   ],
 )


### PR DESCRIPTION
Simply adds the `validators` package to the list of requirements for this library, which was previously missing.

![2018-08-01 16_36_23-archbox - vmware workstation](https://user-images.githubusercontent.com/1904543/43555385-3328d818-963d-11e8-90d4-17a77c45ecb8.png)
