### PR TITLE
Add Trace Methods

### DIFF
--- a/contrast_security/contrast_sdk.py
+++ b/contrast_security/contrast_sdk.py
@@ -34,11 +34,11 @@ class ContrastSdk(object):
 
     def _create_headers(self):
         return {
-                    'Authorization': Util.create_authorization_token(self._username, self._service_key),
-                    'API-Key': self._api_key,
-                    'Content-type': 'application/json',
-                    'Accept': 'application/json'
-                }
+            'Authorization': Util.create_authorization_token(self._username, self._service_key),
+            'API-Key': self._api_key,
+            'Content-type': 'application/json',
+            'Accept': 'application/json'
+        }
 
     def _setup_apis(self):
         self._configure_organization_api()
@@ -122,6 +122,13 @@ class ContrastSdk(object):
         self.get_trace_time_to_remediate_by_severity = self._traces.get_trace_time_to_remediate_by_severity
         self.get_trace_time_to_remediate_current = self._traces.get_trace_time_to_remediate_current
         self.get_trace_time_to_remediate_month_trend = self._traces.get_trace_time_to_remediate_month_trend
+        self.get_trace_card = self._traces.get_trace_card
+        self.get_trace_events_summary = self._traces.get_trace_events_summary
+        self.get_trace_event_details = self._traces.get_trace_event_details
+        self.get_trace_httprequest = self._traces.get_trace_httprequest
+        self.get_trace_httprequest_details = self._traces.get_trace_httprequest_details
+        self.get_trace_recommendation = self._traces.get_trace_recommendation
+        self.get_trace_story = self._traces.get_trace_story
 
     def _configure_alert_api(self):
         self._alert = _AlertApi()

--- a/contrast_security/user_api/trace_api.py
+++ b/contrast_security/user_api/trace_api.py
@@ -16,15 +16,26 @@ class _TraceApi(_ApiSupport):
         return self._get(path, params=trace_filter.get_params_as_json())
 
     def get_org_trace(self, org_uuid, trace_id, expand=None):
-        path = '{org_uuid}/orgtraces/filter/{trace_id}'.format(org_uuid=org_uuid, trace_id=trace_id)
+        path = '{org_uuid}/orgtraces/filter/{trace_id}'.format(
+            org_uuid=org_uuid,
+            trace_id=trace_id
+        )
         return self._get(path, params={'expand': expand})
 
     def get_trace_notes(self, org_uuid, app_id, trace_id):
-        path = '{org_uuid}/applications/{app_id}/traces/{trace_id}/notes'.format(org_uuid=org_uuid,app_id=app_id, trace_id=trace_id)
+        path = '{org_uuid}/applications/{app_id}/traces/{trace_id}/notes'.format(
+            org_uuid=org_uuid,
+            app_id=app_id,
+            trace_id=trace_id
+        )
         return self._get(path)
 
     def create_trace_note(self,org_uuid, app_id, trace_id, note):
-        path = '{org_uuid}/applications/{app_id}/traces/{trace_id}/notes'.format(org_uuid=org_uuid, app_id=app_id,trace_id=trace_id)
+        path = '{org_uuid}/applications/{app_id}/traces/{trace_id}/notes'.format(
+            org_uuid=org_uuid,
+            app_id=app_id,
+            trace_id=trace_id
+        )
         return self._post(path, data={'note': note})
 
     def get_org_trace_ids(self, org_uuid, trace_filter=None):
@@ -38,19 +49,28 @@ class _TraceApi(_ApiSupport):
         return self._get(path)
 
     def get_trace_visibility(self, org_uuid, trace_id):
-        path = '{org_uuid}/orgtraces/{trace_id}/visible'.format(org_uuid=org_uuid, trace_id=trace_id)
+        path = '{org_uuid}/orgtraces/{trace_id}/visible'.format(
+            org_uuid=org_uuid,
+            trace_id=trace_id
+        )
         return self._get(path)
 
     def get_new_trace_trend(self, org_uuid, interval='week', trace_trend_filter=None):
         if trace_trend_filter is None:
             trace_trend_filter = TraceTrendFilter()
-        path = '{org_uuid}/orgtraces/stats/trend/{interval}/new'.format(org_uuid=org_uuid, interval=interval)
+        path = '{org_uuid}/orgtraces/stats/trend/{interval}/new'.format(
+            org_uuid=org_uuid,
+            interval=interval
+        )
         return self._get(path, params=trace_trend_filter.get_params_as_json())
 
     def get_total_trace_trend(self, org_uuid, interval='week', trace_trend_filter=None):
         if trace_trend_filter is None:
             trace_trend_filter = TraceTrendFilter()
-        path = '{org_uuid}/orgtraces/stats/trend/{interval}/total'.format(org_uuid=org_uuid, interval=interval)
+        path = '{org_uuid}/orgtraces/stats/trend/{interval}/total'.format(
+            org_uuid=org_uuid,
+            interval=interval
+        )
         return self._get(path, params=trace_trend_filter.get_params_as_json())
 
     def get_trace_time_to_remediate_by_rule(self, org_uuid,trace_time_to_remediate_filter=None):
@@ -71,4 +91,54 @@ class _TraceApi(_ApiSupport):
 
     def get_trace_time_to_remediate_month_trend(self, org_uuid):
         path = '{org_uuid}/orgtraces/stats/ttr/severity/trend'.format(org_uuid=org_uuid)
+        return self._get(path)
+
+    def get_trace_card(self, org_uuid, trace_uuid):
+        path = '{org_uuid}/traces/{trace_uuid}/card'.format(
+            org_uuid=org_uuid,
+            trace_uuid=trace_uuid
+        )
+        return self._get(path)
+
+    def get_trace_events_summary(self, org_uuid, trace_uuid):
+        path = '{org_uuid}/traces/{trace_uuid}/events/summary'.format(
+            org_uuid=org_uuid,
+            trace_uuid=trace_uuid
+        )
+        return self._get(path)
+
+    def get_trace_event_details(self, org_uuid, trace_uuid, event_id):
+        path = '{org_uuid}/traces/{trace_uuid}/events/{event_id}/details'.format(
+            org_uuid=org_uuid,
+            trace_uuid=trace_uuid,
+            event_id=event_id
+        )
+        return self._get(path)
+
+    def get_trace_httprequest(self, org_uuid, trace_uuid):
+        path = '{org_uuid}/traces/{trace_uuid}/httprequest'.format(
+            org_uuid=org_uuid,
+            trace_uuid=trace_uuid,
+        )
+        return self._get(path)
+
+    def get_trace_httprequest_details(self, org_uuid, trace_uuid):
+        path = '{org_uuid}/traces/{trace_uuid}/httprequest/details'.format(
+            org_uuid=org_uuid,
+            trace_uuid=trace_uuid,
+        )
+        return self._get(path)
+
+    def get_trace_recommendation(self, org_uuid, trace_uuid):
+        path = '{org_uuid}/traces/{trace_uuid}/recommendation'.format(
+            org_uuid=org_uuid,
+            trace_uuid=trace_uuid,
+        )
+        return self._get(path)
+
+    def get_trace_story(self, org_uuid, trace_uuid):
+        path = '{org_uuid}/traces/{trace_uuid}/story'.format(
+            org_uuid=org_uuid,
+            trace_uuid=trace_uuid,
+        )
         return self._get(path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pipreqs==0.4.6
 requests==2.10.0
 nose==1.3.7
+validators==0.12.2

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
   keywords=['contrast', 'security'],
   classifiers=[],
   install_requires=[
-    'requests'
+    'requests',
+    'validators'
   ],
 )


### PR DESCRIPTION
Adds a series of methods for retrieving details about a specific trace.

Additions to `contrast_security/user_api/trace_api.py`:
```
def get_trace_card(self, org_uuid, trace_uuid)
def get_trace_events_summary(self, org_uuid, trace_uuid)
def get_trace_event_details(self, org_uuid, trace_uuid, event_id)
def get_trace_httprequest(self, org_uuid, trace_uuid)
def get_trace_httprequest_details(self, org_uuid, trace_uuid)
def get_trace_recommendation(self, org_uuid, trace_uuid)
def get_trace_story(self, org_uuid, trace_uuid)
```