### PR TITLE
TS-16436 Fix two SDK functions that no longer work

### DIFF
--- a/contrast_security/user_api/route_coverage.py
+++ b/contrast_security/user_api/route_coverage.py
@@ -33,4 +33,4 @@ class _RouteCoverageApi(_ApiSupport):
         if metadata is None:
             metadata = []
         path = '{org_uuid}/applications/{app_id}/route/filter'.format(org_uuid=org_uuid, app_id=app_id)
-        return self._post(path, data={'metadata': metadata, 'sessionID': sessionID}, params={'expand': expand})
+        return self._post(path, json={'metadata': metadata, 'sessionID': sessionID}, params={'expand': expand})

--- a/contrast_security/user_api/session_metadata_api.py
+++ b/contrast_security/user_api/session_metadata_api.py
@@ -8,4 +8,4 @@ class _SessionMetadataApi(_ApiSupport):
 
     def filter_app_session_metadata(self, org_uuid, app_id):
         path = '{org_uuid}/metadata/session/{app_id}/filters'.format(org_uuid=org_uuid, app_id=app_id)
-        return self._post(path)
+        return self._post(path, data={})

--- a/contrast_security/user_api/session_metadata_api.py
+++ b/contrast_security/user_api/session_metadata_api.py
@@ -8,4 +8,4 @@ class _SessionMetadataApi(_ApiSupport):
 
     def filter_app_session_metadata(self, org_uuid, app_id):
         path = '{org_uuid}/metadata/session/{app_id}/filters'.format(org_uuid=org_uuid, app_id=app_id)
-        return self._post(path, data={})
+        return self._post(path, json={})


### PR DESCRIPTION
[A support ticket](https://contrast.atlassian.net/browse/SUP-3721) mentioned that `filter_routes` and `filter_applications` return 400 responses when they should not. They likely stopped working when `getApplicationsByFilterV2` was introduced to Teamserver. This PR fixes them to return 200s and gets the unit tests covering them to pass.

**Whats in here?**
- Pass `json` instead of `data` in `filter_routes` to account fo new

**How to test?**
You may know of a better way to do this, but here's how I did it

- Run teamserver locally in Docker
- Set up your Teamserver with applications, servers, and vulnerabilities using fake-agent-utility
-- `yarn lotsa-vulns -h $HOST --apiKey demo -d requests/vulnerability/java/json/ --totalServers 2 --totalApps 10`
- Log in as a superadmin, grant licenses to the organization and turn on protect
- Log in as an admin, enable those licenses for an application and turn on protect for the application
- Find contrast-sdk-python's `test-config.json.example`, rename it to `test-config.json`, and update it with values from your local Teamserver. A valid `org_id` and `app_id` will be required to test this ticket
- Run the unit tests in contrast-sdk-python with `nosetests`, or set up a run configuration to run & debug nosetest tests. I did this by having a python run configuration run a small file
```
import nose
nose.main()
```
- These two tests should fail in the main branch (because of a 400 response), and pass with this branch (because of a 200 response)
-- `nosetests tests/route_coverage_api_test.py:RouteCoverageApiTest.get_filter_route_test`
-- `nosetests tests/session_metadata_api_test.py:SessionMetadataApiTest.filter_app_session_metadata_test`

TODO:

- [ ] Address #2 on the ticket, confusing parameter use